### PR TITLE
Remove duplicate `search` in Spanish i18n

### DIFF
--- a/src/views/i18n.js
+++ b/src/views/i18n.js
@@ -190,7 +190,8 @@ module.exports = {
       em("todos"),
       ", incluindo aquellos que no seguís. Esta es una lista de publicaciones más populares de tu red de contacto."
     ],
-    latestDescription: "Publicaciones que aquellos que seguís, ordenadas por las más recientes.",
+    latestDescription:
+      "Publicaciones que aquellos que seguís, ordenadas por las más recientes.",
     topics: "Topicos",
     topicsDescription: [
       strong("Topicos"),
@@ -214,11 +215,10 @@ module.exports = {
       strong("hilos privados que te incluyen"),
       ". Las publicaciones privadas están encriptadas para tu llave privada, y contienen el máximo de 7 destinatarios. No se podrán adicionar nuevos destinarios después que empieze el hilo. Seleccioná la hora de una publicación para leer el hilo completo."
     ],
-    search: "Buscar",
     // post actions
     comment: "Comentar",
     reply: "Responder",
-    json: "JSON",
+    json: "JSON"
   },
   de: {
     extended: "Erweitert",


### PR DESCRIPTION
Problem: There are two `search` entries in the Spanish
internationalization.

Solution: Remove one of them!

---

If you merge this into your branch then I can merge your PR into the official branch!