### PR TITLE
lands on /mentions instead of /public/popular/day

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -207,7 +207,7 @@ router
     return next();
   })
   .get("/", async ctx => {
-    ctx.redirect("/public/popular/day");
+    ctx.redirect("/mentions");
   })
   .get("/robots.txt", ctx => {
     ctx.body = "User-agent: *\nDisallow: /";


### PR DESCRIPTION
## What's the problem you solved?
Since we don't have notifications in Oasis yet, it may be useful to have Oasis land on /mentions instead of /public/popular/day. This way user can always start the journey by checking for new mentions.

## What solution are you recommending?
I hard coded the new root redirect to /mentions. A next step could be to create a new setting allow user to pick what should be the "home" tab
